### PR TITLE
[#24] 상품 리스트 조회 시 순환참조 발생 현상 이슈 개선

### DIFF
--- a/src/main/java/spring/marketnori/productcategory/ProductCategoryController.java
+++ b/src/main/java/spring/marketnori/productcategory/ProductCategoryController.java
@@ -2,10 +2,14 @@ package spring.marketnori.productcategory;
 
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ResponseBody;
 import spring.marketnori.productcategory.dto.ProductListResponse;
+
+import java.util.List;
 
 
 @Slf4j
@@ -21,11 +25,21 @@ public class ProductCategoryController {
 
     @ResponseBody
     @GetMapping("/v1/products")
-    public ProductListResponse listProducts() {
-        ProductListResponse productListResponse = new ProductListResponse();
-        productListResponse.setCategories(productCategoryService.findProductsByCategory());
+    public ResponseEntity<ProductListResponse> listProducts() {
+        try {
+            ProductListResponse productListResponse = new ProductListResponse();
+            List<ProductListResponse.ProductCategoryDto> categories = productCategoryService.findProductsByCategory();
 
-        return productListResponse;
+            if (categories.isEmpty()) {
+                log.debug("The product list is empty.");
+                return ResponseEntity.noContent().build();
+            }
+
+            productListResponse.setCategories(categories);
+            return ResponseEntity.ok(productListResponse);
+        } catch (Exception e) {
+            log.error("Error retrieving product list", e);
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST).build();
+        }
     }
-
 }

--- a/src/main/java/spring/marketnori/productcategory/ProductCategoryService.java
+++ b/src/main/java/spring/marketnori/productcategory/ProductCategoryService.java
@@ -2,8 +2,10 @@ package spring.marketnori.productcategory;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
+import spring.marketnori.productcategory.dto.ProductListResponse;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 public class ProductCategoryService {
@@ -15,7 +17,13 @@ public class ProductCategoryService {
         this.productCategoryRepository = productCategoryRepository;
     }
 
-    public List<ProductCategory> findProductsByCategory() {
-        return productCategoryRepository.findAllCategoriesWithProducts();
+    public List<ProductListResponse.ProductCategoryDto> findProductsByCategory() {
+        return convertToDto(productCategoryRepository.findAllCategoriesWithProducts());
+    }
+
+    private List<ProductListResponse.ProductCategoryDto> convertToDto(List<ProductCategory> productCategories) {
+        return productCategories.stream()
+                .map(productCategory -> new ProductListResponse.ProductCategoryDto(productCategory))
+                .collect(Collectors.toList());
     }
 }

--- a/src/main/java/spring/marketnori/productcategory/dto/ProductListResponse.java
+++ b/src/main/java/spring/marketnori/productcategory/dto/ProductListResponse.java
@@ -2,12 +2,47 @@ package spring.marketnori.productcategory.dto;
 
 import lombok.Getter;
 import lombok.Setter;
+import spring.marketnori.product.Product;
 import spring.marketnori.productcategory.ProductCategory;
 
+import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Setter
 @Getter
 public class ProductListResponse {
-    private List<ProductCategory> categories;
+    private List<ProductCategoryDto> categories = new ArrayList<>();
+
+    @Getter
+    @Setter
+    public static class ProductCategoryDto {
+        private Long categoryId;
+        private String categoryName;
+        private List<ProductDto> products;
+
+        public ProductCategoryDto(ProductCategory productCategory) {
+            this.categoryId = productCategory.getProductCategoryId();
+            this.categoryName = productCategory.getCategoryName();
+            this.products = productCategory.getProducts().stream()
+                    .map(product -> new ProductDto(product))
+                    .collect(Collectors.toList());
+        }
+    }
+
+    @Getter
+    @Setter
+    public static class ProductDto {
+        private Long productId;
+        private String productName;
+        private Long stockQuantity;
+        private Long price;
+
+        public ProductDto(Product product) {
+            this.productId = product.getProductId();
+            this.productName = product.getName();
+            this.stockQuantity = product.getStockQuantity();
+            this.price = product.getPrice();
+        }
+    }
 }


### PR DESCRIPTION
### 관련 이슈
* #24 

### 내용 
* 양방향 관계를 맺은 두 엔티티 객체가 서로를 직접 참조하지 않도록 DTO 객체 생성 (ProductCategoryDto, ProductDto)
* 서비스 계층에서 엔티티 객체의 데이터를 Dto 객체에게 전달하기 위한 'convertToDto()' 메서드 추가

close #24